### PR TITLE
add config url to device

### DIFF
--- a/custom_components/purpleair/sensor.py
+++ b/custom_components/purpleair/sensor.py
@@ -46,6 +46,7 @@ class PurpleAirQualitySensor(SensorEntity):
     @property
     def device_info(self):
         return {
+           "configuration_url": f'http://{self.pa_ip_address}',
            "identifiers": {
                # Serial numbers are unique identifiers within a specific domain
                (DOMAIN, self.pa_sensor_id),


### PR DESCRIPTION
The IP is already present on the device page, but I wanted to have the "Visit" link there as well. 